### PR TITLE
Add link to github api documentation

### DIFF
--- a/src/branches/branches.js
+++ b/src/branches/branches.js
@@ -1,3 +1,5 @@
+// @GitHub-API: https://docs.github.com/en/rest/branches/branches
+
 import { GITHUB_TOKEN } from '../utils/token.js';
 import { GITHUB_URL } from '../utils/const.js';
 

--- a/src/branches/protected-branches.js
+++ b/src/branches/protected-branches.js
@@ -1,3 +1,5 @@
+// @GitHub-API: https://docs.github.com/en/rest/branches/branch-protection
+
 import { GITHUB_TOKEN } from '../utils/token.js';
 import { GITHUB_URL } from '../utils/const.js';
 

--- a/src/dependabot/alerts.js
+++ b/src/dependabot/alerts.js
@@ -1,3 +1,5 @@
+// @GitHub-API: https://docs.github.com/en/rest/dependabot/alerts
+
 import {
 	BASE_COUNTER,
 	DEFAULT_INCREMENT,

--- a/src/repositories/repositories.js
+++ b/src/repositories/repositories.js
@@ -1,3 +1,5 @@
+// @GitHub-API: https://docs.github.com/en/rest/dependabot/alerts
+
 import {
 	BASE_COUNTER,
 	DEFAULT_INCREMENT,


### PR DESCRIPTION
Add link to github api documentation
- prefix file with an annotation / comment GitHub-API
- add the link matching the set of functions