### PR TITLE
Enforce trusted publisher

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -9,6 +9,7 @@ jobs:
     environment: prod
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -40,6 +41,4 @@ jobs:
           fi
 
       - name: publish
-        env:
-          NPM_TOKEN: ${{secrets.NPM_PUBLISH}}
         run: rm -rf node-module	.editorconfig tests .github package-lock.json && npm publish --access public

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Enforce trusted publisher
- remove token for publish
- add id-token to generate provenance (and npm auth)